### PR TITLE
README: update bash script to Python script

### DIFF
--- a/docs-rtd/source/hdk/README.rst
+++ b/docs-rtd/source/hdk/README.rst
@@ -144,7 +144,10 @@ Run the command below to build a DCP with desired clock recipes:
 
 .. code:: bash
 
-  ./aws_build_dcp_from_cl.sh -c cl_mem_perf --aws_clk_gen --clock_recipe_a A1 --clock_recipe_b B2 --clock_recipe_c C0 --clock_recipe_hbm H2
+  cd hdk/cl/examples/cl_mem_perf
+  export CL_DIR=$(pwd)
+  cd build/scripts
+  ./aws_build_dcp_from_cl.py -c cl_mem_perf --aws_clk_gen --clock_recipe_a A1 --clock_recipe_b B2 --clock_recipe_c C0 --clock_recipe_hbm H2
 
 **NOTE**: The `cl_sde <./cl/examples/cl_sde/README.html>`__ example does not contain
 the AWS_CLK_GEN component. This command uses the `cl_mem_perf <./cl/examples/cl_mem_perf/README.html>`__

--- a/hdk/README.md
+++ b/hdk/README.md
@@ -84,7 +84,10 @@ The Shell supplies two base clocks to the CL: a 250MHz `clk_main_a0` clock and a
 Run the command below to build a DCP with desired clock recipes:
 
 ```bash
-./aws_build_dcp_from_cl.sh -c cl_mem_perf --aws_clk_gen --clock_recipe_a A1 --clock_recipe_b B2 --clock_recipe_c C0 --clock_recipe_hbm H2
+cd hdk/cl/examples/cl_mem_perf
+export CL_DIR=$(pwd)
+cd build/scripts
+./aws_build_dcp_from_cl.py -c cl_mem_perf --aws_clk_gen --clock_recipe_a A1 --clock_recipe_b B2 --clock_recipe_c C0 --clock_recipe_hbm H2
 ```
 
 **NOTE**: The [cl_sde](./cl/examples/cl_sde/) example does not contain the AWS_CLK_GEN component. This command uses the [cl_mem_perf](./cl/examples/cl_mem_perf/) example to demonstrate the AWS_CLK_GEN usage.


### PR DESCRIPTION
`aws_build_dcp_from_cl.sh` is gone, replaced by `aws_build_dcp_from_cl.py`

Also, expand instructions to correctly configure environment for `cl_mem_perf`

Fixes:

```
./aws_build_dcp_from_cl.sh: No such file or directory
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
