### PR TITLE
fix: don't exit if you want a user to source this script

### DIFF
--- a/hdk_setup.sh
+++ b/hdk_setup.sh
@@ -73,8 +73,10 @@ function check_git_lfs {
         echo "Please install git-lfs:" >&2
         echo "  For RHEL/CentOS/Rocky: sudo yum install git-lfs" >&2
         echo "  For Ubuntu/Debian: sudo apt-get install git-lfs" >&2
-        exit 1
+        return 1
     fi
+    
+    return 0
 }
 
 # Process command line args
@@ -205,7 +207,10 @@ cl_ip_path="hdk/common/ip"
 cl_ip_branch="Vivado_$VIVADO_TOOL_VERSION-$cl_ip_path"
 
 if [ $skip_downloads -eq 0 ]; then
-    check_git_lfs 
+    check_git_lfs
+    if [ $? -ne 0 ]; then
+      return 1
+    fi
     git submodule update --init $cl_ip_path
     git -C $cl_ip_path checkout $cl_ip_branch
 else


### PR DESCRIPTION
# Description of changes:

Calling `exit` inside the `lfs_check` function (after we've confirmed that the script is sourced) will cause the script to close the terminal that opened it.

Changing it to return 1 will propagate a return signal and allow the user to properly read the error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
