### PR TITLE
bugfix for SDE lib h2c buffers mem unmap

### DIFF
--- a/hdk/cl/examples/cl_sde/software/src/sde_lib/sde_mem.c
+++ b/hdk/cl/examples/cl_sde/software/src/sde_lib/sde_mem.c
@@ -145,7 +145,7 @@ int sde_mem_close(struct sde_mem* mem) {
   }
 
   if (mem->h2c_buffers != NULL) {
-    for (size_t i = 0; i < mem->c2h_num_buffers; ++i) {
+    for (size_t i = 0; i < mem->h2c_num_buffers; ++i) {
       ret |= fpga_dma_mem_unmap(&mem->h2c_buffers[i].data_va, mem->h2c_buffers[i].alloc_length);
     }
   }


### PR DESCRIPTION
changing the for loop count from `c2h_num_buffers` to `h2c_num_buffers` as this section refer to the unmap of the h2c buffers. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
