### PR TITLE
Update sde_h2c_simple.c to fix double include sde_utility.h file

### DIFF
--- a/hdk/cl/examples/cl_sde/software/src/sde_h2c_simple.c
+++ b/hdk/cl/examples/cl_sde/software/src/sde_h2c_simple.c
@@ -49,7 +49,6 @@
 #include <sde_utility.h>
 #include <utils/log.h>
 #include <string.h>
-#include <sde_utility.h>
 #include <stdlib.h>
 
 #define H2C_DESC_COALESCE_CNT 32


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The original source code include double c header file **sde_utility.h**.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
