### PR TITLE
F1 EoL updates & notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,6 @@ The documentation for the F2 FPGA Developer Kit including our User Guide, tutori
 
 The F2 FPGA Development Kit is a hardware-software development kit that enables developers to create accelerators for the high-performance accelerator cards on EC2 F2 instances. Using the development kit, you can architect, simulate, optimize, and test your designs.
 
-# ❗Amazon EC2 F1 End of Life Notice❗
-
-We are retiring the F1 instances on December 20, 2025.
-
-Only existing F1 customers who have run F1 instances anytime between Dec 2023 - Dec 2024 can restart or launch new F1 instances. Effective December 20, 2025, F1 instances or access data stored on F1 instance local storage will be no longer available. Please transfer any needed data stored in F1 instance local storage before December 20, 2025.
-
-| aws-fpga F1 Branch       | devKit Version | devAMI                                                                                                                                                                                                                      |
-|:-------------------------|:---------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [f1_xdma_shell](https://github.com/aws/aws-fpga/tree/f1_xdma_shell)            | 1.4.25+        | [FPGA Developer AMI 1.16.1 (Ubuntu)](https://aws.amazon.com/marketplace/pp/prodview-f5kjsenkfkz5u) |
-| [f1_small_shell](https://github.com/aws/aws-fpga/tree/f1_small_shell)           | 1.4.25+        | [FPGA Developer AMI 1.16.1 (Ubuntu)](https://aws.amazon.com/marketplace/pp/prodview-f5kjsenkfkz5u) |
-
 # Support
 
 For any issues with this developer kit documentation or code, please open a [GitHub issue](https://github.com/aws/aws-fpga/issues) with all steps to reproduce.

--- a/docs-rtd/source/hdk/docs/AWS-CLK-GEN-spec.rst
+++ b/docs-rtd/source/hdk/docs/AWS-CLK-GEN-spec.rst
@@ -21,24 +21,13 @@ Table of Contents
 Introduction
 ------------
 
-F1 Shell provides eight clocks to the CL and supports multiple `clock
-recipes <https://github.com/aws/aws-fpga/blob/master/hdk/docs/clock_recipes.csv>`__
-to choose from at the time of CL builds. It also allows to scale clock
-frequencies during runtime (or after AFI/bitstream is loaded into FPGA)
-using
-`dynamic_clock_config <https://github.com/aws/aws-fpga/blob/master/hdk/docs/dynamic_clock_config.md>`__.
-While this architecture provides multiple clock choices for customer
-designs, it locks up the global clock routing resources in the CL
-region. This can pose limitations for customers who do not require all
-the clocks provided from Shell to the CL.
-
-Therefore, F2 Shell provides only two clocks - ``clk_main_a0`` and
-``clk_hbm_ref`` - to the CL resulting in efficient use of global routing
-resources. The ``clk_main_a0`` is currently a fixed frequency 250MHz
-clock (❗ dynamic scaling of frequency as F1 using the SW APIs will be added
-in a future release). The ``clk_hbm_ref`` is a fixed frequency 100MHz clock
-which can be used by customer as a reference clock for their MMCMs. This scheme
-provides flexibility for customers to devise their own clocking mechanisms with
+F2 Shell provides two clocks - ``clk_main_a0`` and ``clk_hbm_ref`` - to the CL,
+enabling more efficient use of global routing resources compared to F1. The
+``clk_main_a0 is`` currently a fixed frequency 250MHz clock (❗️ dynamic
+frequency scaling as in F1 using the SW APIs will be added in a future release).
+The ``clk_hbm_ref`` is a fixed frequency 100MHz clock which can be used by
+customers as a reference clock for their MMCMs. This scheme provides
+flexibility for customers to devise their own clocking mechanisms with the
 desired number of clocks.
 
 In order to provide F1’s clock recipes in F2, as well as support Vitis

--- a/docs-rtd/source/hdk/docs/Clock-Recipes-User-Guide.rst
+++ b/docs-rtd/source/hdk/docs/Clock-Recipes-User-Guide.rst
@@ -20,13 +20,9 @@ Table of Content
 Introduction
 ------------
 
-F2 Shell offers two clocks - ``clk_main_a0`` and ``clk_hbm_ref`` to the
-CL. This is different from F1 Shell, which offers total of 8 clocks from
-Shell to the CL as described in `F1 Shell Interface
-Spec <./AWS-Shell-Interface-Specification.html#clocks>`__.
-Offering fewer clocks from the Shell to CL is beneficial because it does
-not lock up the routing resources for customers who do not require all
-the clocks from the Shell.
+F2 Shell offers two clocks - ``clk_main_a0`` and ``clk_hbm_ref`` - to the CL
+compared to the 8 clocks offered in F1 Shell. Fewer clocks to the CL helps
+avoid routing congestion and free up more resources for customer usage.
 
 The ``clk_main_a0`` defaults to 250MHz. Dynamic reconfiguration of the
 frequency for ``clk_main_a0`` is currently NOT supported. However, this
@@ -320,11 +316,5 @@ Clock Consideration When Porting CL Designs from F1 into F2
 
 3. F2 supports same clock recipe build switches as F1 to simplify
    porting of F1 designs into F2.
-
-References
-----------
-
-`F1 Dynamic Clock
-Configuration <https://github.com/aws/aws-fpga/blob/master/hdk/docs/dynamic_clock_config.md>`__
 
 `Back to HDK README <../README.html>`__

--- a/hdk/docs/AWS_CLK_GEN_spec.md
+++ b/hdk/docs/AWS_CLK_GEN_spec.md
@@ -15,9 +15,7 @@
 
 ## Introduction
 
-F1 Shell provides eight clocks to the CL and supports multiple [clock recipes](https://github.com/aws/aws-fpga/blob/master/hdk/docs/clock_recipes.csv) to choose from at the time of CL builds. It also allows to scale clock frequencies during runtime (or after AFI/bitstream is loaded into FPGA) using [dynamic_clock_config](https://github.com/aws/aws-fpga/blob/master/hdk/docs/dynamic_clock_config.md). While this architecture provides multiple clock choices for customer designs, it locks up the global clock routing resources in the CL region. This can pose limitations for customers who do not require all the clocks provided from Shell to the CL.
-
-Therefore, F2 Shell provides only two clocks - `clk_main_a0` and `clk_hbm_ref` - to the CL resulting in efficient use of global routing resources. The `clk_main_a0` is currently a fixed frequency 250MHz clock (:exclamation: dynamic scaling of frequency as F1 using the SW APIs will be added in a future release). The `clk_hbm_ref` is a fixed frequency 100MHz clock which can be used by customer as a reference clock for their MMCMs. This scheme provides flexibility for customers to devise their own clocking mechanisms with desired number of clocks.
+F2 Shell provides two clocks - `clk_main_a0` and `clk_hbm_ref` - to the CL, enabling more efficient use of global routing resources compared to F1. The `clk_main_a0 is` currently a fixed frequency 250MHz clock (❗️ dynamic frequency scaling as in F1 using the SW APIs will be added in a future release). The `clk_hbm_ref` is a fixed frequency 100MHz clock which can be used by customers as a reference clock for their MMCMs. This scheme provides flexibility for customers to devise their own clocking mechanisms with the desired number of clocks.
 
 In order to provide F1’s clock recipes in F2, as well as support Vitis development in F2, AWS offers the Clock Generator (AWS_CLK_GEN) IP. AWS_CLK_GEN provides various clocks to the CL design and supports dynamic frequency scaling. The Vitis XSA for F2 relies on AWS_CLK_GEN for all the clocking needs in the design. This document details the Microarchitecture Specification for AWS_CLK_GEN.
 

--- a/hdk/docs/Clock_Recipes_User_Guide.md
+++ b/hdk/docs/Clock_Recipes_User_Guide.md
@@ -13,7 +13,8 @@
 
 ## Introduction
 
-F2 Shell offers two clocks - `clk_main_a0` and `clk_hbm_ref` to the CL. This is different from F1 Shell, which offers total of 8 clocks from Shell to the CL as described in [F1 Shell Interface Spec](https://github.com/aws/aws-fpga/blob/master/hdk/docs/AWS_Shell_Interface_Specification.md#clocks). Offering fewer clocks from the Shell to CL is beneficial because it does not lock up the routing resources for customers who do not require all the clocks from the Shell.
+F2 Shell offers two clocks - `clk_main_a0` and `clk_hbm_ref` - to the CL compared to the 8 clocks offered in F1 Shell. Fewer clocks to the CL help avoid routing congestions and free up more resources for customer usage.
+
 
 The `clk_main_a0` defaults to 250MHz. Dynamic reconfiguration of the frequency for `clk_main_a0` is currently NOT supported. However, this will be supported in future.
 
@@ -91,6 +92,3 @@ Support for SW API to do clock frequency dynamic configuration is available usin
 
 3. F2 supports same clock recipe build switches as F1 to simplify porting of F1 designs into F2.
 
-## References
-
-[F1 Dynamic Clock Configuration](https://github.com/aws/aws-fpga/blob/master/hdk/docs/dynamic_clock_config.md)


### PR DESCRIPTION
*Description of changes:*

AWS is retiring F1 instance types as of 2025/12/20 (today). This change updates the F2 devkit branch to indicate F1 retirement.