### PR TITLE
Add required packages for test_create_afi.py

### DIFF
--- a/hdk/scripts/start_venv.sh
+++ b/hdk/scripts/start_venv.sh
@@ -20,8 +20,8 @@ mypy-boto3-ec2>=1.34.4
 mypy-boto3-s3>=1.34.0
 pydantic==2.5.3
 pydantic-core==2.14.6
-coverage==7.13.2
-moto==5.1.20
+coverage>=7.13.2
+moto>=5.1.20
 EOF
 
 echo "Creating and activating virtual environment in the script directory"

--- a/hdk/scripts/start_venv.sh
+++ b/hdk/scripts/start_venv.sh
@@ -20,6 +20,8 @@ mypy-boto3-ec2>=1.34.4
 mypy-boto3-s3>=1.34.0
 pydantic==2.5.3
 pydantic-core==2.14.6
+coverage==7.13.2
+moto==5.1.20
 EOF
 
 echo "Creating and activating virtual environment in the script directory"


### PR DESCRIPTION
*Issue #, if available:*

```
08:06:54 ubuntu@ip-1-1-1-1 scripts ±|f2 ✗|→ source start_venv.sh
-bash: /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt: cannot overwrite existing file
Creating and activating virtual environment in the script directory
Requirement already satisfied: pip in ./venv/lib/python3.12/site-packages (25.3)
Requirement already satisfied: boto3>=1.33.13 in ./venv/lib/python3.12/site-packages (from -r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 1)) (1.42.37)
Requirement already satisfied: boto3-stubs>=1.34.4 in ./venv/lib/python3.12/site-packages (from -r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 2)) (1.42.37)
Requirement already satisfied: botocore>=1.33.13 in ./venv/lib/python3.12/site-packages (from -r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 3)) (1.42.37)
Requirement already satisfied: botocore-stubs>=1.34.4 in ./venv/lib/python3.12/site-packages (from -r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 4)) (1.42.37)
Requirement already satisfied: mypy-boto3-ec2>=1.34.4 in ./venv/lib/python3.12/site-packages (from -r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 5)) (1.42.37)
Requirement already satisfied: mypy-boto3-s3>=1.34.0 in ./venv/lib/python3.12/site-packages (from -r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 6)) (1.42.37)
Requirement already satisfied: pydantic==2.5.3 in ./venv/lib/python3.12/site-packages (from -r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 7)) (2.5.3)
Requirement already satisfied: pydantic-core==2.14.6 in ./venv/lib/python3.12/site-packages (from -r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 8)) (2.14.6)
Requirement already satisfied: annotated-types>=0.4.0 in ./venv/lib/python3.12/site-packages (from pydantic==2.5.3->-r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 7)) (0.7.0)
Requirement already satisfied: typing-extensions>=4.6.1 in ./venv/lib/python3.12/site-packages (from pydantic==2.5.3->-r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 7)) (4.15.0)
Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in ./venv/lib/python3.12/site-packages (from boto3>=1.33.13->-r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 1)) (1.1.0)
Requirement already satisfied: s3transfer<0.17.0,>=0.16.0 in ./venv/lib/python3.12/site-packages (from boto3>=1.33.13->-r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 1)) (0.16.0)
Requirement already satisfied: python-dateutil<3.0.0,>=2.1 in ./venv/lib/python3.12/site-packages (from botocore>=1.33.13->-r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 3)) (2.9.0.post0)
Requirement already satisfied: urllib3!=2.2.0,<3,>=1.25.4 in ./venv/lib/python3.12/site-packages (from botocore>=1.33.13->-r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 3)) (2.6.3)
Requirement already satisfied: six>=1.5 in ./venv/lib/python3.12/site-packages (from python-dateutil<3.0.0,>=2.1->botocore>=1.33.13->-r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 3)) (1.17.0)
Requirement already satisfied: types-s3transfer in ./venv/lib/python3.12/site-packages (from boto3-stubs>=1.34.4->-r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 2)) (0.16.0)
Requirement already satisfied: types-awscrt in ./venv/lib/python3.12/site-packages (from botocore-stubs>=1.34.4->-r /home/ubuntu/aws-fpga/hdk/scripts/requirements.txt (line 4)) (0.31.1)
Virtual environment created in /home/ubuntu/aws-fpga/hdk/scripts/venv and packages installed successfully!
08:07:13 ((venv) ) ubuntu@ip-1-1-1-1 scripts ±|f2 ✗|→ python3 test_create_afi.py
Traceback (most recent call last):
  File "/home/ubuntu/aws-fpga/hdk/scripts/test_create_afi.py", line 22, in <module>
    import coverage
ModuleNotFoundError: No module named 'coverage'
08:07:25 ((venv) ) ubuntu@ip-1-1-1-1 scripts ±|f2 ✗|→ pip install coverage
Collecting coverage
  Downloading coverage-7.13.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl.metadata (8.5 kB)
Downloading coverage-7.13.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl (253 kB)
Installing collected packages: coverage
Successfully installed coverage-7.13.2
08:07:54 ((venv) ) ubuntu@ip-1-1-1-1 scripts ±|f2 ✗|→ python3 test_create_afi.py
Traceback (most recent call last):
  File "/home/ubuntu/aws-fpga/hdk/scripts/test_create_afi.py", line 40, in <module>
    from moto import mock_s3
ModuleNotFoundError: No module named 'moto'
08:08:07 ((venv) ) ubuntu@ip-1-1-1-1 scripts ±|f2 ✗|→ pip install moto
…

```

@czfpga in accordance with our meeting yesterday :)
*Description of changes:*
Adding required packages for the test script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
