### PR TITLE
Fix: Improved null test to run your c script simulation

### DIFF
--- a/hdk/cl/examples/cl_dram_hbm_dma/verif/tests/test_null.sv
+++ b/hdk/cl/examples/cl_dram_hbm_dma/verif/tests/test_null.sv
@@ -17,11 +17,17 @@
 
 
 module test_null();
+ import tb_type_defines_pkg::*;
+
+   `include "base_test_utils.svh";
+
 
    initial begin
       int exit_code;
 
       tb.power_up();
+       initialize_ddr();
+       deselect_cl_tst_hw();
 
       tb.test_main(exit_code);
 


### PR DESCRIPTION
While performing C-script simulations for the cl_dram_hbm_dma example, I encountered an issue where the simulation environment was not correctly synchronizing with the software-side execution in test_null.sv.

Since FPGA resources are costly, verifying the C-runtime logic through simulation before hardware deployment is critical. This PR adds specific helper functions/logic to test_null.sv to:

Ensure the C-script triggers the hardware simulation correctly.

Provide better visibility into software-to-hardware handshakes during null tests.

Prevent simulation hangs when running the specific HBM/DRAM DMA software stack.

Verified on the HDK simulation environment.

<img width="1011" height="532" alt="pnggg" src="https://github.com/user-attachments/assets/89afbab6-1776-410a-ba6b-42cb9784cf64" />
