### PR TITLE
Fix image path for CL SDE Block Diagram

### DIFF
--- a/hdk/cl/examples/cl_sde/README.md
+++ b/hdk/cl/examples/cl_sde/README.md
@@ -22,7 +22,7 @@ The CL_SDE example implements the FPGA custom logic used to generate the AFI to 
 
 ### System Diagram
 
-![Diagram](./../../../../../docs-rtd/source/_static/cl_sde_images/CL_SDE_Block_Diagram.jpg)
+![Diagram](./../../../../docs-rtd/source/_static/cl_sde_images/CL_SDE_Block_Diagram.jpg)
 
 ## Functional Description
 


### PR DESCRIPTION
Updated the path for the system diagram image in the README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
